### PR TITLE
Add Python to PATH of SPS HySDS PGE Base Image

### DIFF
--- a/docker/Dockerfile_sps-hysds-pge-base
+++ b/docker/Dockerfile_sps-hysds-pge-base
@@ -2,6 +2,9 @@ FROM hysds/pge-base:develop
 
 USER root
 
+# Add /opt/conda/bin to the PATH environment variable
+ENV PATH="/opt/conda/bin:${PATH}"
+
 RUN /home/ops/verdi/bin/pip install cwl-runner
 
 # Need pyyaml for writing workflow yaml


### PR DESCRIPTION
## Overview

When testing the CHIRP rebinning CWL workflow, it was found that the workflow needed Python to be in the PATH environment variable.