### PR TITLE
#155: Updates to enable Job's Results

### DIFF
--- a/publish_job.py
+++ b/publish_job.py
@@ -82,7 +82,7 @@ def main():
     args = parse_args()
 
     # get sts and sns aws clients
-    # sts_client, sns_client = get_sts_and_sns_clients(args.aws_auth_method)
+    sts_client, sns_client = get_sts_and_sns_clients(args.aws_auth_method)
 
     # contstruct final job data json object
     job_data = {"id": args.job_id}
@@ -95,11 +95,11 @@ def main():
     topic_arn = args.jobs_data_sns_topic_arn
     print(job_data)
 
-    # print(
-    #     sns_client.publish(
-    #         TopicArn=topic_arn, Message=json.dumps(job_data), MessageGroupId=args.job_id
-    #     )
-    # )
+    print(
+        sns_client.publish(
+            TopicArn=topic_arn, Message=json.dumps(job_data), MessageGroupId=args.job_id
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/publish_job.py
+++ b/publish_job.py
@@ -3,34 +3,21 @@ import boto3
 import argparse
 import json
 import os
+import regex
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--job_id", type=str, default="", help="Job ID of job being executed"
-    )
-    parser.add_argument(
-        "--job_status", type=str, default="", help="Status of job being executed"
-    )
-    parser.add_argument(
-        "--job_inputs",
-        type=str,
-        default="[]",
-        help="JSON array of WPS-T job input objects associated with job",
-    )
-    parser.add_argument(
-        "--job_outputs",
-        type=str,
-        default="[]",
-        help="JSON array of WPS-T job output objects associated with job",
-    )
-    parser.add_argument(
-        "--tags",
-        type=str,
-        default="{}",
-        help="JSON array of WPS-T job output objects associated with job",
-    )
+    parser = argparse.ArgumentParser(description="Update job status and results")
+
+    parser.add_argument("job_id", type=str, help="Job ID (required)")
+    parser.add_argument("--update_status", type=str, help="Job status")
+    parser.add_argument("--update_results", action='store_true', help="Update results")
+
+    args = parser.parse_args()
+
+    if not args.update_status and not args.update_results:
+        parser.error("Either --update_status or --update_results must be specified.")
+
     parser.add_argument("--aws_auth_method", type=str, default="iam")
     parser.add_argument("--jobs_data_sns_topic_arn", type=str, default="")
 
@@ -68,28 +55,51 @@ def get_sts_and_sns_clients(aws_auth_method):
     return sts_client, client
 
 
+def find_output():
+    """
+    This function parses the stdout file and extracts the workflow output
+    :return:
+    """
+    # open stdout file
+    f = open("stdout.txt", "r")
+    stdout = f.read()
+
+    pattern = regex.compile(r'\{(?:[^{}]|(?R))*\}')
+    json_found = pattern.findall(stdout)
+    cwl_output = json.loads(json_found[-1])
+    print(json.dumps(cwl_output, indent=2))
+    # TODO: Make the keyword products dynamic
+    if cwl_output.get("products") is not None:
+        print("Job completed. Product successfully found.")
+        job_status = "Succeeded"
+        return job_status, cwl_output
+    else:
+        print("Job failed. Product not generated.")
+        job_status = "Failed"
+        return job_status, {}
+
 def main():
     args = parse_args()
 
     # get sts and sns aws clients
-    sts_client, sns_client = get_sts_and_sns_clients(args.aws_auth_method)
+    # sts_client, sns_client = get_sts_and_sns_clients(args.aws_auth_method)
 
     # contstruct final job data json object
-    job_data = {
-        "id": args.job_id,
-        "inputs": args.job_inputs,
-        "outputs": args.job_outputs,
-        "tags": args.tags,
-        "status": args.job_status,
-    }
-
+    job_data = {"id": args.job_id}
+    if args.update_status:
+        job_data["status"] = args.update_status
+    if args.update_results:
+        job_status, cwl_output = find_output()
+        job_data["status"] = job_status
+        job_data["outputs"] = cwl_output
     topic_arn = args.jobs_data_sns_topic_arn
+    print(job_data)
 
-    print(
-        sns_client.publish(
-            TopicArn=topic_arn, Message=json.dumps(job_data), MessageGroupId=args.job_id
-        )
-    )
+    # print(
+    #     sns_client.publish(
+    #         TopicArn=topic_arn, Message=json.dumps(job_data), MessageGroupId=args.job_id
+    #     )
+    # )
 
 
 if __name__ == "__main__":

--- a/publish_job.py
+++ b/publish_job.py
@@ -12,14 +12,13 @@ def parse_args():
     parser.add_argument("job_id", type=str, help="Job ID (required)")
     parser.add_argument("--update_status", type=str, help="Job status")
     parser.add_argument("--update_results", action='store_true', help="Update results")
+    parser.add_argument("--aws_auth_method", type=str, default="iam")
+    parser.add_argument("--jobs_data_sns_topic_arn", type=str, default="")
 
     args = parser.parse_args()
 
     if not args.update_status and not args.update_results:
         parser.error("Either --update_status or --update_results must be specified.")
-
-    parser.add_argument("--aws_auth_method", type=str, default="iam")
-    parser.add_argument("--jobs_data_sns_topic_arn", type=str, default="")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Updated and refactored `publish_job.py`.

The new usage of the publish_job.py is as follows:
To update job status: `/usr/app/publish_job.py [job_id] --update_status [status]`
```
e.g. python publish_job.py 65665-65464-58787 --update_status running
```
To update job results: `/usr/app/publish_job.py [job_id] --update_results`
```
e.g. python publish_job.py 65665-65464-58787 --update_results 
```