### PR TITLE
Job configuration inputs through workflows

### DIFF
--- a/create_cwl_yml.py
+++ b/create_cwl_yml.py
@@ -51,13 +51,13 @@ def get_system_workflow_inputs():
 def create_yml():
     workflow_yaml = dict()
     # Reading in job inputs
+    sys_wfl_inps = get_system_workflow_inputs()
     wfl_inps = get_inputs_from_context()
+    workflow_yaml.update(sys_wfl_inps)
     workflow_yaml.update(wfl_inps)
     workflow_yaml["job_inputs"] = json.dumps(wfl_inps)
     workflow_yaml["job_id"] = get_job_id_from_context()
     # setting other static / env values for workflow run
-    sys_wfl_inps = get_system_workflow_inputs()
-    workflow_yaml.update(sys_wfl_inps)
     # write out yaml
     with open(r"workflow_yaml.yml", "w") as file:
         yaml.dump(workflow_yaml, file)

--- a/create_cwl_yml.py
+++ b/create_cwl_yml.py
@@ -41,10 +41,10 @@ def get_job_id_from_context():
 def get_system_workflow_inputs():
     # Read in environment variales
     sys_wfl_inps = dict()
-    sys_wfl_inps["staging_bucket"] = os.environ["STAGING_BUCKET"]
-    sys_wfl_inps["client_id"] = os.environ["CLIENT_ID"]
-    sys_wfl_inps["dapa_api"] = os.environ["DAPA_API"]
-    sys_wfl_inps["jobs_data_sns_topic_arn"] = os.environ["JOBS_DATA_SNS_TOPIC_ARN"]
+    sys_wfl_inps["staging_bucket"] = os.getenv("STAGING_BUCKET", default="")
+    sys_wfl_inps["client_id"] = os.getenv("CLIENT_ID", default="")
+    sys_wfl_inps["dapa_api"] = os.getenv("DAPA_API", default="")
+    sys_wfl_inps["jobs_data_sns_topic_arn"] = os.getenv("JOBS_DATA_SNS_TOPIC_ARN", default="")
     return sys_wfl_inps
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,5 @@ FROM ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:develop
 
 USER root
 
-# Accept environment variables as build parameters
-ARG STAGING_BUCKET
-ARG CLIENT_ID
-ARG DAPA_API
-ARG JOBS_DATA_SNS_TOPIC_ARN
-
-# Set environment variables
-ENV STAGING_BUCKET=${STAGING_BUCKET}
-ENV CLIENT_ID=${CLIENT_ID}
-ENV DAPA_API=${DAPA_API}
-ENV JOBS_DATA_SNS_TOPIC_ARN=${JOBS_DATA_SNS_TOPIC_ARN}
-
 # TODO: change entrypoint, since we will not be running a bash script
 ENTRYPOINT ["/cwl/run_cwl_workflow.sh"]


### PR DESCRIPTION
## Purpose
Changes to propagate job configuration workflow inputs through job inputs instead of through process image environment variables.

## Proposed Changes
- [CHANGE] use `os.getenv()` instead of `os.environ` when creating input yaml to support non-existent environment variables with backward compatibility
- [REMOVE] build args from image build

## Issues
- fixes bug #230 where domain specific images were causing issues between venues

## Testing
- validated execution chirp workflow works with changes
- ran passing regression tests in MCP-Dev
